### PR TITLE
pytest dependency is only needed when running test.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,15 @@ setup_args = dict(
 install_requires = [
     'requests',
     'frozendict',
-    'pytest'
 ]
 
+extras_require = {
+    'test': ['pytest']
+}
+
 if __name__ == '__main__':
-    setup(**setup_args, install_requires=install_requires)
+    setup(
+        **setup_args,
+        install_requires=install_requires,
+        extras_require=extras_require
+    )


### PR DESCRIPTION
Moved pytest to test extra, so it will not get installed on production servers.