### PR TITLE
Add proxy support

### DIFF
--- a/gitea/gitea.py
+++ b/gitea/gitea.py
@@ -22,7 +22,12 @@ class Gitea:
     CREATE_TEAM = """/orgs/%s/teams"""  # <orgname>
 
     def __init__(
-        self, gitea_url: str, token_text=None, auth=None, verify=True, log_level="INFO"
+        self,
+        gitea_url: str,
+        token_text=None,
+        auth=None,
+        verify=True,
+        log_level="INFO",
     ):
         """Initializing Gitea-instance
 

--- a/gitea/gitea.py
+++ b/gitea/gitea.py
@@ -28,6 +28,8 @@ class Gitea:
         auth=None,
         verify=True,
         log_level="INFO",
+        # example: "socks5h://127.0.0.1:9050"
+        proxy=None,
     ):
         """Initializing Gitea-instance
 
@@ -47,6 +49,12 @@ class Gitea:
         }
         self.url = gitea_url
         self.requests = requests.Session()
+
+        if proxy:
+            self.requests.proxies = {
+                "http": proxy,
+                "https": proxy,
+            }
 
         # Manage authentification
         if not token_text and not auth:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-requests
+requests[socks]
 pytest
 immutabledict


### PR DESCRIPTION
needed for [darktea etc](https://github.com/milahu/darknet-git-hosting-services)

formatting in 33137fd185d9f518a0d357de7abba3e8b780cbca to reduce diff noise

<details>
<summary>
example
</summary>

```py
#!/usr/bin/env python3

import os
import sys
import logging



logging_level = "INFO"
logging_level = "DEBUG"

logging.basicConfig(
    #format='%(asctime)s %(levelname)s %(message)s',
    # also log the logger %(name)s, so we can filter by logger name
    format='%(asctime)s %(name)s %(levelname)s %(message)s',
    level=logging_level,
)

logger = logging.getLogger("fetch-subs")



# https://github.com/Langenfeld/py-gitea
sys.path.insert(0, os.path.dirname(__file__) + "/py-gitea")
from gitea import *

logins = {
    "darktea.onion": {
        "url": "http://it7otdanqu7ktntxzm427cba6i53w6wlanlh23v5i3siqmos47pzhvyd.onion",
        # /user/settings/applications -> generate token
        "token": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
    },
}

login = logins["darktea.onion"]

# NOTE socks5h protocol is required to fix DNS leaks (opsec fail!!)
# and to fix Name or service not known errors for onion domains 
proxy = "socks5h://127.0.0.1:9050"

gitea = Gitea(login["url"], login["token"], proxy=proxy)

print("Gitea Version: " + gitea.get_version())
#print("API-Token belongs to user: " + gitea.get_user().username)
```
