### PR TITLE
Added missing Team features

### DIFF
--- a/gitea/apiobject.py
+++ b/gitea/apiobject.py
@@ -119,10 +119,10 @@ class Organization(ApiObject):
             setattr(t, "_organization", self)
         return teams
 
-    def get_team(self, name) -> "Team":
+    def get_team(self, name, ignore_case : bool = False) -> "Team":
         teams = self.get_teams()
         for team in teams:
-            if team.name == name:
+            if (not ignore_case and team.name == name) or (ignore_case and team.name.lower() == name.lower()):
                 return team
         raise NotFoundException("Team not existent in organization.")
 

--- a/gitea/gitea.py
+++ b/gitea/gitea.py
@@ -352,6 +352,15 @@ class Gitea:
             "repo.releases",
             "repo.ext_wiki",
         ),
+        units_map: Dict[str, str] = {
+            "repo.code": "none",
+            "repo.issues": "none",
+            "repo.ext_issues": "none",
+            "repo.wiki": "none",
+            "repo.pulls": "none",
+            "repo.releases": "none",
+            "repo.ext_wiki": "none",
+        },
     ):
         """Creates a Team.
 
@@ -370,6 +379,7 @@ class Gitea:
                 "can_create_org_repo": can_create_org_repo,
                 "includes_all_repositories": includes_all_repositories,
                 "units": units,
+                "units_map": units_map,
             },
         )
         if "id" in result:


### PR DESCRIPTION
- Optional parameter `units_map` in `gitea.create_team`, as available at least for Gitlab 1.22.1
- Optional parameter `ignore_case` in `Organization.get_team` to ignore the casing of the name string