### PR TITLE
Repository.delete_file function added

### DIFF
--- a/gitea/apiobject.py
+++ b/gitea/apiobject.py
@@ -653,6 +653,16 @@ class Repository(ApiObject):
         url = f"/repos/{self.owner.username}/{self.name}/contents/{file_path}"
         data.update({"sha": file_sha, "content": content})
         return self.gitea.requests_put(url, data)
+    
+    def delete_file(
+        self, file_path: str, file_sha: str, data: dict = None
+    ):
+        """https://try.gitea.io/api/swagger#/repository/repoCreateFile"""
+        if not data:
+            data = {}
+        url = f"/repos/{self.owner.username}/{self.name}/contents/{file_path}"
+        data.update({"sha": file_sha})
+        return self.gitea.requests_delete(url, data)
 
     def delete(self):
         self.gitea.requests_delete(

--- a/gitea/gitea.py
+++ b/gitea/gitea.py
@@ -144,9 +144,13 @@ class Gitea:
             self.logger.error(message)
             raise Exception(message)
 
-    def requests_delete(self, endpoint: str):
-        request = self.requests.delete(self.__get_url(endpoint), headers=self.headers)
-        if request.status_code not in [204]:
+    def requests_delete(self, endpoint: str, data: dict = None):
+        if not data:
+            data = {}
+        request = self.requests.delete(
+            self.__get_url(endpoint), headers=self.headers, data=json.dumps(data)
+        )
+        if request.status_code not in [200, 204]:
             message = f"Received status code: {request.status_code} ({request.url})"
             self.logger.error(message)
             raise Exception(message)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -216,6 +216,21 @@ def test_change_file(instance):
     assert len(readme_content) > 0
     assert TESTFILE_CONENTE in str(base64.b64decode(readme_content))
 
+def test_delete_file(instance):
+    TESTFILE_CONENTE = "TestStringFileContent2"
+    TESTFILE_CONENTE_B64 = base64.b64encode(bytes(TESTFILE_CONENTE, "utf-8"))
+    org = Organization.request(instance, test_org)
+    repo = org.get_repository(test_repo)
+    repo.create_file("testfile2.md", content=TESTFILE_CONENTE_B64.decode("ascii"))
+    # test if putting was successful
+    content = repo.get_git_content()
+    readmes = [c for c in content if c.name == "testfile2.md"]
+    assert len(readmes) > 0
+    # test if deleting was successful
+    repo.delete_file("testfile2.md", readmes[0].sha)
+    content = repo.get_git_content()
+    readmes = [c for c in content if c.name == "testfile2.md"]
+    assert len(readmes) == 0
 
 def test_create_branch(instance):
     org = Organization.request(instance, test_org)


### PR DESCRIPTION
Please find attached a PR to add the Repository.delete_file that comes in addition to the existing creat_file and change_file.
I add to modify the interface of the Gitea.requests_delete function to accept an optional data argument (like requests_put) to pass a delete message as wel as the sha of the file to delete. As this argument is optional it should be safe with existing calls to requests_delete.

Test file also added