### PR TITLE
fix: authentication check prevents public API access

### DIFF
--- a/gitea/gitea.py
+++ b/gitea/gitea.py
@@ -56,7 +56,7 @@ class Gitea:
             }
 
         # Manage authentification
-        if not token_text and not auth:
+        if token_text and auth:
             raise ValueError("Please provide auth or token_text, but not both")
         if token_text:
             self.headers["Authorization"] = "token " + token_text


### PR DESCRIPTION
This pull request addresses a bug in the authentication logic in gitea/gitea.py.

- The current conditional `if not token_text and not auth:` does not match the associated error message and prevents access to public API endpoints without authentication.
  https://github.com/Langenfeld/py-gitea/blob/7e4ad3bb0d24c7d1484946e9bb4f364234a88df6/gitea/gitea.py#L59-L60
- The conditional is updated to `if token_text and auth:`, which allows requests to public endpoints without providing a token or authentication.
- without this change the if clause doesn't even check for what is mentioned in the error message

fixes #43 