### PR TITLE
fix: paginate get_branches to support repositories with many branches

### DIFF
--- a/gitea/apiobject.py
+++ b/gitea/apiobject.py
@@ -424,7 +424,7 @@ class Repository(ApiObject):
 
     def get_branches(self) -> List["Branch"]:
         """Get all the Branches of this Repository."""
-        results = self.gitea.requests_get(Repository.REPO_BRANCHES % (self.owner.username, self.name))
+        results = self.gitea.requests_get_paginated(Repository.REPO_BRANCHES % (self.owner.username, self.name))
         return [Branch.parse_response(self.gitea, result) for result in results]
 
     def add_branch(self, create_from: Branch, newname: str) -> "Branch":


### PR DESCRIPTION
## Summary

`Repository.get_branches()` was using `requests_get` instead of 
`requests_get_paginated`, causing it to silently return only the 
first page of results for repositories with many branches.

Closes #48

## Change
Single-line fix: `requests_get` → `requests_get_paginated`