### PR TITLE
fix: correct Milestone._patchable_fields (was copy-pasted from Repository)

### DIFF
--- a/gitea/apiobject.py
+++ b/gitea/apiobject.py
@@ -730,20 +730,10 @@ class Milestone(ApiObject):
     }
 
     _patchable_fields = {
-        "allow_merge_commits",
-        "allow_rebase",
-        "allow_rebase_explicit",
-        "allow_squash_merge",
-        "archived",
-        "default_branch",
         "description",
-        "has_issues",
-        "has_pull_requests",
-        "has_wiki",
-        "ignore_whitespace_conflicts",
-        "name",
-        "private",
-        "website",
+        "due_on",
+        "state",
+        "title",
     }
 
     @classmethod


### PR DESCRIPTION
## Summary

`Milestone._patchable_fields` contained fields copied from `Repository` 
(e.g. `allow_rebase`, `has_wiki`, `private`) which don't exist on a Milestone
and would cause silent failures or unexpected API errors when calling 
`milestone.commit()`.

Corrected to match the actual Gitea API for 
`PATCH /repos/{owner}/{repo}/milestones/{id}`:
- `title`
- `description`  
- `due_on`
- `state`

## Reference
Screenshot from Gitea Swagger API:

<img width="1281" height="1092" alt="image" src="https://github.com/user-attachments/assets/edeb6771-4a08-4498-b147-4974965cdfab" />

https://gitea.com/api/swagger#/issue/issueEditMilestone